### PR TITLE
Add openpyxl to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+openpyxl==3.0.9
 pandas==1.2.0
 PySimpleGUI==4.41.2


### PR DESCRIPTION
openpyxl is needed to manipulate xlsx files with pandas. You're mentioning the installation in your corresponding YouTube video, but missed adding it to the requirements.txt file. 😄 